### PR TITLE
Use C99, incorporate jody_hash to replace MD5, general cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+#
+# Build ignores
+#
+.*
+*.o
+*.o.*
+*.a
+*.so
+*.so.*
+*.1.gz
+
+#
+# Never ignore these
+#
+!.gitignore
+
+#
+# Normal output and testing dirs
+#
+/fdupes
+
+#
+# Backups / patches
+#
+*~
+*.orig
+*.rej
+/*.patch
+
+#
+# debugging stuff
+#
+core
+.gdb_history
+.gdbinit
+

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ MKDIR   = mkdir -p
 # Make Configuration
 #
 CC ?= gcc
-COMPILER_OPTIONS = -Wall -O -g
+COMPILER_OPTIONS = -Wall -pedantic -std=gnu99 -O2 -g
 
 CFLAGS= $(COMPILER_OPTIONS) -I. -DVERSION=\"$(VERSION)\" $(EXTERNAL_MD5) $(OMIT_GETOPT_LONG) $(FILEOFFSET_64BIT)
 

--- a/Makefile
+++ b/Makefile
@@ -111,12 +111,12 @@ fdupes: $(OBJECT_FILES)
 	$(CC) $(CFLAGS) -o fdupes $(OBJECT_FILES)
 
 installdirs:
-	test -d $(BIN_DIR) || $(MKDIR) $(BIN_DIR)
-	test -d $(MAN_DIR) || $(MKDIR) $(MAN_DIR)
+	test -d $(BIN_DIR) || $(MKDIR) $(DESTDIR)/$(BIN_DIR)
+	test -d $(MAN_DIR) || $(MKDIR) $(DESTDIR)/$(MAN_DIR)
 
 install: fdupes installdirs
-	$(INSTALL_PROGRAM)	fdupes   $(BIN_DIR)/$(PROGRAM_NAME)
-	$(INSTALL_DATA)		fdupes.1 $(MAN_DIR)/$(PROGRAM_NAME).$(MAN_EXT)
+	$(INSTALL_PROGRAM)	fdupes   $(DESTDIR)/$(BIN_DIR)/$(PROGRAM_NAME)
+	$(INSTALL_DATA)		fdupes.1 $(DESTDIR)/$(MAN_DIR)/$(PROGRAM_NAME).$(MAN_EXT)
 
 clean:
 	$(RM) $(OBJECT_FILES)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,15 @@ FILEOFFSET_64BIT = -D_FILE_OFFSET_BITS=64
 # built in MD5 message digest routines) uncomment the following
 # line (try this if you're having trouble with built in code).
 #
-#EXTERNAL_MD5 = -DEXTERNAL_MD5=\"md5sum\"
+#SUM_FUNC = -DEXTERNAL_MD5=\"md5sum\"
+
+#
+# To use Jody Bruchon's hash function instead of MD5 signatures,
+# uncomment the following line. This algorithm is faster than MD5 but
+# has occasional hash collisions that may result in more full-file
+# comparisons in some instances.
+#
+#SUM_FUNC = -DJODY_HASH
 
 #####################################################################
 # Developer Configuration Section                                   #
@@ -80,7 +88,7 @@ MKDIR   = mkdir -p
 CC ?= gcc
 COMPILER_OPTIONS = -Wall -pedantic -std=gnu99 -O2 -g
 
-CFLAGS= $(COMPILER_OPTIONS) -I. -DVERSION=\"$(VERSION)\" $(EXTERNAL_MD5) $(OMIT_GETOPT_LONG) $(FILEOFFSET_64BIT)
+CFLAGS= $(COMPILER_OPTIONS) -I. -DVERSION=\"$(VERSION)\" $(SUM_FUNC) $(OMIT_GETOPT_LONG) $(FILEOFFSET_64BIT)
 
 INSTALL_PROGRAM = $(INSTALL) -c -m 0755
 INSTALL_DATA    = $(INSTALL) -c -m 0644
@@ -91,7 +99,7 @@ INSTALL_DATA    = $(INSTALL) -c -m 0644
 #
 #ADDITIONAL_OBJECTS = getopt.o
 
-OBJECT_FILES = fdupes.o md5/md5.o $(ADDITIONAL_OBJECTS)
+OBJECT_FILES = fdupes.o md5/md5.o jody_hash.o $(ADDITIONAL_OBJECTS)
 
 #####################################################################
 # no need to modify anything beyond this point                      #

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ FILEOFFSET_64BIT = -D_FILE_OFFSET_BITS=64
 # has occasional hash collisions that may result in more full-file
 # comparisons in some instances.
 #
-#SUM_FUNC = -DJODY_HASH
+SUM_FUNC = -DJODY_HASH
 
 #####################################################################
 # Developer Configuration Section                                   #

--- a/fdupes.c
+++ b/fdupes.c
@@ -11,12 +11,12 @@
    The above copyright notice and this permission notice shall be
    included in all copies or substantial portions of the Software.
 
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
-   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #include <stdio.h>
@@ -71,7 +71,7 @@ uint_fast16_t flags = 0;
 
 #define PARTIAL_MD5_SIZE 4096
 
-/* 
+/*
 
 TODO: Partial sums (for working with very large files).
 
@@ -103,7 +103,7 @@ typedef struct _file {
 } file_t;
 
 typedef struct _filetree {
-  file_t *file; 
+  file_t *file;
   struct _filetree *left;
   struct _filetree *right;
 } filetree_t;
@@ -168,10 +168,10 @@ static inline dev_t getdevice(char *filename) {
 
 static inline ino_t getinode(char *filename) {
   struct stat s;
-   
+
   if (stat(filename, &s) != 0) return 0;
 
-  return s.st_ino;   
+  return s.st_ino;
 }
 
 static inline time_t getmtime(char *filename) {
@@ -210,17 +210,17 @@ static char **cloneargs(int argc, char **argv)
 static int findarg(char *arg, int start, int argc, char **argv)
 {
   int x;
-  
+
   for (x = start; x < argc; x++)
-    if (strcmp(argv[x], arg) == 0) 
+    if (strcmp(argv[x], arg) == 0)
       return x;
 
   return x;
 }
 
 /* Find the first non-option argument after specified option. */
-static int nonoptafter(char *option, int argc, char **oldargv, 
-		      char **newargv, int optind) 
+static int nonoptafter(char *option, int argc, char **oldargv,
+		      char **newargv, int optind)
 {
   int x;
   int targetind;
@@ -228,7 +228,7 @@ static int nonoptafter(char *option, int argc, char **oldargv,
   int startat = 1;
 
   targetind = findarg(option, 1, argc, oldargv);
-    
+
   for (x = optind; x < argc; x++) {
     testind = findarg(newargv[x], startat, argc, oldargv);
     if (testind > targetind) return x;
@@ -294,7 +294,7 @@ static int grokdir(char *dir, file_t **filelistp)
       if (lastchar >= 0 && dir[lastchar] != '/')
 	strcat(newfile->d_name, "/");
       strcat(newfile->d_name, dirinfo->d_name);
-      
+
       if (ISFLAG(flags, F_EXCLUDEHIDDEN)) {
 	fullname = strdup(newfile->d_name);
 	name = basename(fullname);
@@ -348,7 +348,7 @@ static int grokdir(char *dir, file_t **filelistp)
 
 #ifndef EXTERNAL_MD5
 
-/* If EXTERNAL_MD5 is not defined, use L. Peter Deutsch's MD5 library. 
+/* If EXTERNAL_MD5 is not defined, use L. Peter Deutsch's MD5 library.
  */
 static char *getcrcsignatureuntil(char *filename, off_t max_read)
 {
@@ -356,17 +356,17 @@ static char *getcrcsignatureuntil(char *filename, off_t max_read)
   off_t fsize;
   off_t toread;
   md5_state_t state;
-  md5_byte_t digest[16];  
+  md5_byte_t digest[16];
   static md5_byte_t chunk[CHUNK_SIZE];
-  static char signature[16*2 + 1]; 
+  static char signature[16*2 + 1];
   char *sigp;
   FILE *file;
-   
+
   md5_init(&state);
 
- 
+
   fsize = filesize(filename);
-  
+
   if (max_read != 0 && fsize > max_read)
     fsize = max_read;
 
@@ -375,7 +375,7 @@ static char *getcrcsignatureuntil(char *filename, off_t max_read)
     errormsg("error opening file %s\n", filename);
     return NULL;
   }
- 
+
   while (fsize > 0) {
     toread = (fsize >= CHUNK_SIZE) ? CHUNK_SIZE : fsize;
     if (fread(chunk, toread, 1, file) != 1) {
@@ -437,13 +437,13 @@ static char *getcrcsignature(char *filename)
     errormsg("error invoking %s\n", EXTERNAL_MD5);
     exit(1);
   }
- 
+
   free(command);
 
   if (fgets(signature, 256, result) == NULL) {
     errormsg("error generating signature for %s\n", filename);
     return NULL;
-  }    
+  }
   separator = strchr(signature, ' ');
   if (separator) *separator = '\0';
 
@@ -457,9 +457,9 @@ static char *getcrcsignature(char *filename)
 static inline void purgetree(filetree_t *checktree)
 {
   if (checktree->left != NULL) purgetree(checktree->left);
-    
+
   if (checktree->right != NULL) purgetree(checktree->right);
-    
+
   free(checktree);
 }
 
@@ -480,7 +480,7 @@ static int registerfile(filetree_t **branch, file_t *file)
     errormsg("out of memory!\n");
     exit(1);
   }
-  
+
   (*branch)->file = file;
   (*branch)->left = NULL;
   (*branch)->right = NULL;
@@ -507,21 +507,21 @@ static file_t **checkmatch(filetree_t **root, filetree_t *checktree, file_t *fil
   char *crcsignature;
   off_t fsize;
 
-  /* If device and inode fields are equal one of the files is a 
-     hard link to the other or the files have been listed twice 
+  /* If device and inode fields are equal one of the files is a
+     hard link to the other or the files have been listed twice
      unintentionally. We don't want to flag these files as
      duplicates unless the user specifies otherwise.
-  */    
+  */
 
-  if (!ISFLAG(flags, F_CONSIDERHARDLINKS) && (getinode(file->d_name) == 
+  if (!ISFLAG(flags, F_CONSIDERHARDLINKS) && (getinode(file->d_name) ==
       checktree->file->inode) && (getdevice(file->d_name) ==
-      checktree->file->device)) return NULL; 
+      checktree->file->device)) return NULL;
 
   fsize = filesize(file->d_name);
-  
-  if (fsize < checktree->file->size) 
+
+  if (fsize < checktree->file->size)
     cmpresult = -1;
-  else 
+  else
     if (fsize > checktree->file->size) cmpresult = 1;
   else
     if (ISFLAG(flags, F_PERMISSIONS) &&
@@ -587,7 +587,7 @@ static file_t **checkmatch(filetree_t **root, filetree_t *checktree, file_t *fil
       }
 
       cmpresult = strcmp(file->crcsignature, checktree->file->crcsignature);
-      /*if (cmpresult != 0) errormsg("P   on %s vs %s\n", 
+      /*if (cmpresult != 0) errormsg("P   on %s vs %s\n",
           file->d_name, checktree->file->d_name);
       else errormsg("P F on %s vs %s\n", file->d_name,
           checktree->file->d_name);
@@ -609,14 +609,14 @@ static file_t **checkmatch(filetree_t **root, filetree_t *checktree, file_t *fil
       registerfile(&(checktree->right), file);
       return NULL;
     }
-  } else 
+  } else
   {
     getfilestats(file);
     return &checktree->file;
   }
 }
 
-/* Do a bit-for-bit comparison in case two different files produce the 
+/* Do a bit-for-bit comparison in case two different files produce the
    same signature. Unlikely, but better safe than sorry. */
 
 static int confirmmatch(FILE *file1, FILE *file2)
@@ -625,7 +625,7 @@ static int confirmmatch(FILE *file1, FILE *file2)
   unsigned char c2[CHUNK_SIZE];
   size_t r1;
   size_t r2;
-  
+
   fseek(file1, 0, SEEK_SET);
   fseek(file2, 0, SEEK_SET);
 
@@ -636,7 +636,7 @@ static int confirmmatch(FILE *file1, FILE *file2)
     if (r1 != r2) return 0; /* file lengths are different */
     if (memcmp (c1, c2, r1)) return 0; /* file contents are different */
   } while (r2);
-  
+
   return 1;
 }
 
@@ -675,7 +675,7 @@ static void summarizematches(file_t *files)
       printf("%d duplicate files (in %d sets), occupying %.1f kilobytes\n\n", numfiles, numsets, numbytes / 1000.0);
     else
       printf("%d duplicate files (in %d sets), occupying %.1f megabytes\n\n", numfiles, numsets, numbytes / (1000.0 * 1000.0));
- 
+
   }
 }
 
@@ -700,7 +700,7 @@ static void printmatches(file_t *files)
       printf("\n");
 
     }
-      
+
     files = files->next;
   }
 }
@@ -723,7 +723,7 @@ char *revisefilename(char *path, int seq)
 
   strcpy(scratch, path);
   dot = strrchr(scratch, '.');
-  if (dot) 
+  if (dot)
   {
     *dot = 0;
     sprintf(newpath, "%s%s%d.%s", scratch, REVISE_APPEND, seq, dot + 1);
@@ -781,7 +781,7 @@ static void deletefiles(file_t *files, int prompt, FILE *tty)
   int i;
 
   curfile = files;
-  
+
   while (curfile) {
     if (curfile->hasdupes) {
       counter = 1;
@@ -792,10 +792,10 @@ static void deletefiles(file_t *files, int prompt, FILE *tty)
 	counter++;
 	tmpfile = tmpfile->duplicates;
       }
-      
+
       if (counter > max) max = counter;
     }
-    
+
     curfile = curfile->next;
   }
 
@@ -837,7 +837,7 @@ static void deletefiles(file_t *files, int prompt, FILE *tty)
       else /* prompt for files to preserve */
 
       do {
-	printf("Set %d of %d, preserve files [1 - %d, all]", 
+	printf("Set %d of %d, preserve files [1 - %d, all]",
           curgroup, groups, counter);
 	if (ISFLAG(flags, F_SHOWSIZE)) printf(" (%jd byte%seach)", (intmax_t)files->size,
 	  (files->size != 1) ? "s " : " ");
@@ -873,20 +873,20 @@ static void deletefiles(file_t *files, int prompt, FILE *tty)
 	while (token != NULL) {
 	  if (strncasecmp(token, "all", 4) == 0)
 	    for (x = 0; x <= counter; x++) preserve[x] = 1;
-	  
+
 	  number = 0;
 	  sscanf(token, "%d", &number);
 	  if (number > 0 && number <= counter) preserve[number] = 1;
-	  
+
 	  token = strtok(NULL, " ,\n");
 	}
-      
+
 	for (sum = 0, x = 1; x <= counter; x++) sum += preserve[x];
       } while (sum < 1); /* make sure we've preserved at least one file */
 
       printf("\n");
 
-      for (x = 1; x <= counter; x++) { 
+      for (x = 1; x <= counter; x++) {
 	if (preserve[x])
 	  printf("   [+] %s\n", dupelist[x]->d_name);
 	else {
@@ -900,7 +900,7 @@ static void deletefiles(file_t *files, int prompt, FILE *tty)
       }
       printf("\n");
     }
-    
+
     files = files->next;
   }
 
@@ -932,7 +932,7 @@ static inline int sort_pairs_by_filename(file_t *f1, file_t *f2)
   return strcmp(f1->d_name, f2->d_name);
 }
 
-static void registerpair(file_t **matchlist, file_t *newmatch, 
+static void registerpair(file_t **matchlist, file_t *newmatch,
 		  int (*comparef)(file_t *f1, file_t *f2))
 {
   file_t *traverse;
@@ -947,7 +947,7 @@ static void registerpair(file_t **matchlist, file_t *newmatch,
     if (comparef(newmatch, traverse) <= 0)
     {
       newmatch->duplicates = traverse;
-      
+
       if (back == 0)
       {
 	*matchlist = newmatch; /* update pointer to head of list */
@@ -972,7 +972,7 @@ static void registerpair(file_t **matchlist, file_t *newmatch,
 	break;
       }
     }
-    
+
     back = traverse;
     traverse = traverse->duplicates;
   }
@@ -989,7 +989,7 @@ static void help_text()
   printf("                  \tthe end of the option, manpage for more details)\n");
   printf(" -s --symlinks    \tfollow symlinks\n");
   printf(" -H --hardlinks   \tnormally, when two or more files point to the same\n");
-  printf("                  \tdisk area they are treated as non-duplicates; this\n"); 
+  printf("                  \tdisk area they are treated as non-duplicates; this\n");
   printf("                  \toption will change this behavior\n");
   printf(" -n --noempty     \texclude zero-length files from consideration\n");
   printf(" -A --nohidden    \texclude hidden files from consideration\n");
@@ -998,7 +998,7 @@ static void help_text()
   printf(" -S --size        \tshow size of duplicate files\n");
   printf(" -m --summarize   \tsummarize dupe information\n");
   printf(" -q --quiet       \thide progress indicator\n");
-  printf(" -d --delete      \tprompt user for files to preserve and delete all\n"); 
+  printf(" -d --delete      \tprompt user for files to preserve and delete all\n");
   printf("                  \tothers; important: under particular circumstances,\n");
   printf("                  \tdata may be lost when using this option together\n");
   printf("                  \twith -s or --symlinks, or when specifying a\n");
@@ -1033,9 +1033,9 @@ int main(int argc, char **argv) {
   char **oldargv;
   int firstrecurse;
   ordertype_t ordertype = ORDER_TIME;
-  
+
 #ifndef OMIT_GETOPT_LONG
-  static struct option long_options[] = 
+  static struct option long_options[] =
   {
     { "omitfirst", 0, 0, 'f' },
     { "recurse", 0, 0, 'r' },
@@ -1157,7 +1157,7 @@ int main(int argc, char **argv) {
 
   if (ISFLAG(flags, F_RECURSEAFTER)) {
     firstrecurse = nonoptafter("--recurse:", argc, oldargv, argv, optind);
-    
+
     if (firstrecurse == argc)
       firstrecurse = nonoptafter("-R", argc, oldargv, argv, optind);
 
@@ -1184,13 +1184,13 @@ int main(int argc, char **argv) {
     if (!ISFLAG(flags, F_HIDEPROGRESS)) fprintf(stderr, "\r%40s\r", " ");
     exit(0);
   }
-  
+
   curfile = files;
 
   while (curfile) {
-    if (!checktree) 
+    if (!checktree)
       registerfile(&checktree, curfile);
-    else 
+    else
       match = checkmatch(&checktree, checktree, curfile);
 
     if (match != NULL) {
@@ -1199,7 +1199,7 @@ int main(int argc, char **argv) {
 	curfile = curfile->next;
 	continue;
       }
-      
+
       file2 = fopen((*match)->d_name, "rb");
       if (!file2) {
 	fclose(file1);
@@ -1215,7 +1215,7 @@ int main(int argc, char **argv) {
         curfile->duplicates = match->duplicates;
         match->duplicates = curfile;*/
       }
-      
+
       fclose(file1);
       fclose(file2);
     }
@@ -1244,11 +1244,11 @@ int main(int argc, char **argv) {
     }
   }
 
-  else 
+  else
 
     if (ISFLAG(flags, F_SUMMARIZEMATCHES))
       summarizematches(files);
-      
+
     else
 
       printmatches(files);

--- a/fdupes.c
+++ b/fdupes.c
@@ -82,7 +82,7 @@ typedef enum {
   ORDER_NAME
 } ordertype_t;
 
-char *program_name;
+const char *program_name;
 
 uint_fast16_t flags = 0;
 
@@ -171,7 +171,7 @@ static void escapefilename(char *escape_list, char **filename_ptr)
   }
 }
 
-static inline off_t filesize(char *filename) {
+static inline off_t filesize(const char * const filename) {
   struct stat s;
 
   if (stat(filename, &s) != 0) return -1;
@@ -179,7 +179,7 @@ static inline off_t filesize(char *filename) {
   return s.st_size;
 }
 
-static inline dev_t getdevice(char *filename) {
+static inline dev_t getdevice(const char * const filename) {
   struct stat s;
 
   if (stat(filename, &s) != 0) return 0;
@@ -187,7 +187,7 @@ static inline dev_t getdevice(char *filename) {
   return s.st_dev;
 }
 
-static inline ino_t getinode(char *filename) {
+static inline ino_t getinode(const char * const filename) {
   struct stat s;
 
   if (stat(filename, &s) != 0) return 0;
@@ -195,7 +195,7 @@ static inline ino_t getinode(char *filename) {
   return s.st_ino;
 }
 
-static inline time_t getmtime(char *filename) {
+static inline time_t getmtime(const char * const filename) {
   struct stat s;
 
   if (stat(filename, &s) != 0) return 0;
@@ -203,7 +203,7 @@ static inline time_t getmtime(char *filename) {
   return s.st_mtime;
 }
 
-static char **cloneargs(int argc, char **argv)
+static char **cloneargs(const int argc, char **argv)
 {
   int x;
   char **args;
@@ -228,7 +228,8 @@ static char **cloneargs(int argc, char **argv)
   return args;
 }
 
-static int findarg(char *arg, int start, int argc, char **argv)
+static int findarg(const char * const arg, const int start,
+		const int argc, char **argv)
 {
   int x;
 
@@ -240,8 +241,8 @@ static int findarg(char *arg, int start, int argc, char **argv)
 }
 
 /* Find the first non-option argument after specified option. */
-static int nonoptafter(char *option, int argc, char **oldargv,
-		      char **newargv, int optind)
+static int nonoptafter(const char *option, const int argc,
+		char **oldargv, char **newargv, int optind)
 {
   int x;
   int targetind;
@@ -259,7 +260,7 @@ static int nonoptafter(char *option, int argc, char **oldargv,
   return x;
 }
 
-static int grokdir(char *dir, file_t **filelistp)
+static int grokdir(const char *dir, file_t ** const filelistp)
 {
   DIR *cd;
   file_t *newfile;
@@ -369,7 +370,8 @@ static int grokdir(char *dir, file_t **filelistp)
 
 /* Use Jody Bruchon's hash function instead of MD5 */
 #ifdef JODY_HASH
-static hash_t *getcrcsignatureuntil(char *filename, off_t max_read)
+static hash_t *getcrcsignatureuntil(const char * const filename,
+		const off_t max_read)
 {
   off_t fsize;
   off_t toread;

--- a/fdupes.c
+++ b/fdupes.c
@@ -568,7 +568,7 @@ static int same_permissions(char* name1, char* name2)
 #endif	/* JODY_HASH */
 
 /* Change to hashes */
-static file_t **checkmatch(filetree_t **root, filetree_t *checktree, file_t *file)
+static file_t **checkmatch(filetree_t *checktree, file_t *file)
 {
   int cmpresult;
   CRC_T *crcsignature;
@@ -664,14 +664,14 @@ static file_t **checkmatch(filetree_t **root, filetree_t *checktree, file_t *fil
 
   if (cmpresult < 0) {
     if (checktree->left != NULL) {
-      return checkmatch(root, checktree->left, file);
+      return checkmatch(checktree->left, file);
     } else {
       registerfile(&(checktree->left), file);
       return NULL;
     }
   } else if (cmpresult > 0) {
     if (checktree->right != NULL) {
-      return checkmatch(root, checktree->right, file);
+      return checkmatch(checktree->right, file);
     } else {
       registerfile(&(checktree->right), file);
       return NULL;
@@ -1259,7 +1259,7 @@ int main(int argc, char **argv) {
     if (!checktree)
       registerfile(&checktree, curfile);
     else
-      match = checkmatch(&checktree, checktree, curfile);
+      match = checkmatch(checktree, curfile);
 
     if (match != NULL) {
       file1 = fopen(curfile->d_name, "rb");

--- a/jody_hash.c
+++ b/jody_hash.c
@@ -30,7 +30,6 @@ extern hash_t jody_block_hash(const hash_t * data,
 	register hash_t hash = start_hash;
 	unsigned int len;
 	hash_t tail;
-//	const unsigned char *tail_p;
 
 #ifdef ARCH_HAS_LITTLE_ENDIAN
 	/* Little-endian 64-bit hash_t tail mask */

--- a/jody_hash.c
+++ b/jody_hash.c
@@ -1,0 +1,88 @@
+/* Jody Bruchon's fast hashing function
+ *
+ * This function was written to generate a fast hash that also has a
+ * fairly low collision rate. The collision rate is much higher than
+ * a secure hash algorithm, but the calculation is drastically simpler
+ * and faster.
+ *
+ * Copyright (C) 2014-2015 by Jody Bruchon <jody@jodybruchon.com>
+ * Released under the terms of the GNU GPL version 2
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "jody_hash.h"
+
+/* Hash a block of arbitrary size; must be divisible by sizeof(hash_t)
+ * The first block should pass a start_hash of zero.
+ * All blocks after the first should pass start_hash as the value
+ * returned by the last call to this function. This allows hashing
+ * of any amount of data. If data is not divisible by the size of
+ * hash_t, it is MANDATORY that the caller provide a data buffer
+ * which is divisible by sizeof(hash_t). */
+extern hash_t jody_block_hash(const hash_t * data,
+		const hash_t start_hash, const unsigned int count)
+{
+	register hash_t hash = start_hash;
+	unsigned int len;
+	hash_t tail;
+//	const unsigned char *tail_p;
+
+#ifdef ARCH_HAS_LITTLE_ENDIAN
+	/* Little-endian 64-bit hash_t tail mask */
+	const hash_t le64_tail_mask[] = {
+		0x0000000000000000,
+		0xff00000000000000,
+		0xffff000000000000,
+		0xffffff0000000000,
+		0xffffffff00000000,
+		0xffffffffff000000,
+		0xffffffffffff0000,
+		0xffffffffffffff00,
+		0xffffffffffffffff,
+	};
+ #define TAIL_MASK le64_tail_mask
+#else
+	/* Big-endian 64-bit hash_t tail mask */
+	const hash_t be64_tail_mask[] = {
+		0x0000000000000000,
+		0x00000000000000ff,
+		0x000000000000ffff,
+		0x0000000000ffffff,
+		0x00000000ffffffff,
+		0x000000ffffffffff,
+		0x0000ffffffffffff,
+		0x00ffffffffffffff,
+		0xffffffffffffffff,
+	};
+ #define TAIL_MASK be64_tail_mask
+#endif	/* ARCH_HAS_LITTLE_ENDIAN */
+
+	len = count / sizeof(hash_t);
+	for (; len > 0; len--) {
+		hash += *data;
+		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(hash_t) * 8 - JODY_HASH_SHIFT);
+		hash += (*data & (hash_t)0x000000ff);
+		hash ^= (*data);
+		hash += (*data & (hash_t)0xffffff00);
+		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(hash_t) * 8 - JODY_HASH_SHIFT);
+		hash += *data;
+		data++;
+	}
+
+	/* Handle data tail (for blocks indivisible by sizeof(hash_t)) */
+	len = count & (sizeof(hash_t) - 1);
+	if (len) {
+		tail = *data;
+		tail &= TAIL_MASK[len];
+		hash += tail;
+		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(hash_t) * 8 - JODY_HASH_SHIFT);
+		hash += (tail & (hash_t)0x000000ff);
+		hash ^= (tail);
+		hash += (tail & (hash_t)0xffffff00);
+		hash = (hash << JODY_HASH_SHIFT) | hash >> (sizeof(hash_t) * 8 - JODY_HASH_SHIFT);
+		hash += tail;
+	}
+
+	return hash;
+}

--- a/jody_hash.c
+++ b/jody_hash.c
@@ -7,6 +7,10 @@
  *
  * Copyright (C) 2014-2015 by Jody Bruchon <jody@jodybruchon.com>
  * Released under the terms of the GNU GPL version 2
+ *
+ * 2015-01-03: Re-licensed under the fdupes license as detailed in the
+ * README file. Though no longer required, I would still request that
+ * anyone who improves this code send me patches! Thanks. -Jody
  */
 
 #include <stdio.h>

--- a/jody_hash.c
+++ b/jody_hash.c
@@ -24,7 +24,7 @@
  * of any amount of data. If data is not divisible by the size of
  * hash_t, it is MANDATORY that the caller provide a data buffer
  * which is divisible by sizeof(hash_t). */
-extern hash_t jody_block_hash(const hash_t * data,
+extern hash_t jody_block_hash(const hash_t * restrict data,
 		const hash_t start_hash, const unsigned int count)
 {
 	register hash_t hash = start_hash;

--- a/jody_hash.h
+++ b/jody_hash.h
@@ -12,7 +12,7 @@
 typedef uint64_t hash_t;
 #define JODY_HASH_SHIFT 11
 
-extern hash_t jody_block_hash(const hash_t * const restrict data,
+extern hash_t jody_block_hash(const hash_t * restrict data,
 		const hash_t start_hash, const unsigned int count);
 
 #endif	/* _JODY_HASH_H */

--- a/jody_hash.h
+++ b/jody_hash.h
@@ -1,0 +1,18 @@
+/* Jody Bruchon's fast hashing function (headers)
+ *
+ * Copyright (C) 2014-2015 by Jody Bruchon <jody@jodybruchon.com>
+ * Released under the terms of the GNU GPL version 2
+ */
+
+#ifndef _JODY_HASH_H
+#define _JODY_HASH_H
+
+#include <stdint.h>
+
+typedef uint64_t hash_t;
+#define JODY_HASH_SHIFT 11
+
+extern hash_t jody_block_hash(const hash_t * const data,
+		const hash_t start_hash, const unsigned int count);
+
+#endif	/* _JODY_HASH_H */

--- a/jody_hash.h
+++ b/jody_hash.h
@@ -12,7 +12,7 @@
 typedef uint64_t hash_t;
 #define JODY_HASH_SHIFT 11
 
-extern hash_t jody_block_hash(const hash_t * const data,
+extern hash_t jody_block_hash(const hash_t * const restrict data,
 		const hash_t start_hash, const unsigned int count);
 
 #endif	/* _JODY_HASH_H */

--- a/jody_hash.h
+++ b/jody_hash.h
@@ -1,7 +1,7 @@
 /* Jody Bruchon's fast hashing function (headers)
  *
  * Copyright (C) 2014-2015 by Jody Bruchon <jody@jodybruchon.com>
- * Released under the terms of the GNU GPL version 2
+ * See jody_hash.c for more information.
  */
 
 #ifndef _JODY_HASH_H

--- a/md5/md5.c
+++ b/md5/md5.c
@@ -42,6 +42,7 @@
   1999-05-03 lpd Original version.
  */
 
+#include <stdint.h>
 #include "md5.h"
 #include <string.h>
 

--- a/md5/md5.h
+++ b/md5/md5.h
@@ -52,7 +52,7 @@
  */
 
 typedef unsigned char md5_byte_t; /* 8-bit byte */
-typedef unsigned int md5_word_t; /* 32-bit word */
+typedef uint32_t md5_word_t; /* 32-bit word */
 
 /* Define the state of the MD5 Algorithm. */
 typedef struct md5_state_s {


### PR DESCRIPTION
fdupes contains many extremely small functions that are called in
few places and can benefit from explicit inlining. Functions
should also be declared "static" where appropriate to allow for
better compiler optimization. Added "static" and "inline" where
appropriate.

Removed "long long" references, replacing with proper C99 types.
Changed Makefile to use C99, higher optimization, and pedantic
compiler warnings. Added headers needed for C99 types.