### PR TITLE
Remove the dead and broken EXTERNAL_MD5.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,6 @@ FILEOFFSET_64BIT = -D_FILE_OFFSET_BITS=64
 #
 #OMIT_GETOPT_LONG = -DOMIT_GETOPT_LONG
 
-#
-# To use the md5sum program for calculating signatures (instead of the
-# built in MD5 message digest routines) uncomment the following
-# line (try this if you're having trouble with built in code).
-#
-#EXTERNAL_MD5 = -DEXTERNAL_MD5=\"md5sum\"
-
 #####################################################################
 # Developer Configuration Section                                   #
 #####################################################################
@@ -80,7 +73,7 @@ MKDIR   = mkdir -p
 CC ?= gcc
 COMPILER_OPTIONS = -Wall -O -g
 
-CFLAGS= $(COMPILER_OPTIONS) -I. -DVERSION=\"$(VERSION)\" $(EXTERNAL_MD5) $(OMIT_GETOPT_LONG) $(FILEOFFSET_64BIT)
+CFLAGS= $(COMPILER_OPTIONS) -I. -DVERSION=\"$(VERSION)\" $(OMIT_GETOPT_LONG) $(FILEOFFSET_64BIT)
 
 INSTALL_PROGRAM = $(INSTALL) -c -m 0755
 INSTALL_DATA    = $(INSTALL) -c -m 0644

--- a/fdupes.c
+++ b/fdupes.c
@@ -33,9 +33,7 @@
 #include <errno.h>
 #include <libgen.h>
 
-#ifndef EXTERNAL_MD5
 #include "md5/md5.h"
-#endif
 
 #define ISFLAG(a,b) ((a & b) == b)
 #define SETFLAG(a,b) (a |= b)
@@ -345,10 +343,6 @@ int grokdir(char *dir, file_t **filelistp)
   return filecount;
 }
 
-#ifndef EXTERNAL_MD5
-
-/* If EXTERNAL_MD5 is not defined, use L. Peter Deutsch's MD5 library. 
- */
 char *getcrcsignatureuntil(char *filename, off_t max_read)
 {
   int x;
@@ -409,49 +403,6 @@ char *getcrcpartialsignature(char *filename)
 {
   return getcrcsignatureuntil(filename, PARTIAL_MD5_SIZE);
 }
-
-#endif /* [#ifndef EXTERNAL_MD5] */
-
-#ifdef EXTERNAL_MD5
-
-/* If EXTERNAL_MD5 is defined, use md5sum program to calculate signatures.
- */
-char *getcrcsignature(char *filename)
-{
-  static char signature[256];
-  char *command;
-  char *separator;
-  FILE *result;
-
-  command = (char*) malloc(strlen(filename)+strlen(EXTERNAL_MD5)+2);
-  if (command == NULL) {
-    errormsg("out of memory\n");
-    exit(1);
-  }
-
-  sprintf(command, "%s %s", EXTERNAL_MD5, filename);
-
-  result = popen(command, "r");
-  if (result == NULL) {
-    errormsg("error invoking %s\n", EXTERNAL_MD5);
-    exit(1);
-  }
- 
-  free(command);
-
-  if (fgets(signature, 256, result) == NULL) {
-    errormsg("error generating signature for %s\n", filename);
-    return NULL;
-  }    
-  separator = strchr(signature, ' ');
-  if (separator) *separator = '\0';
-
-  pclose(result);
-
-  return signature;
-}
-
-#endif /* [#ifdef EXTERNAL_MD5] */
 
 void purgetree(filetree_t *checktree)
 {


### PR DESCRIPTION
It was broken in 54c920e06ea5c6550b8fade9bfee8f3cb60a389f (fdupes-1.50-PR2):
fdupes.c:531: undefined reference to `getcrcpartialsignature'
fdupes.c:546: undefined reference to `getcrcpartialsignature'

Seing as noone cared to fix it for seven years I'm removing the dead broken code.