### PR TITLE
revised md5.c to compile under OSX

### DIFF
--- a/md5/md5.c
+++ b/md5/md5.c
@@ -46,7 +46,11 @@
 #include <string.h>
 
 /* endianness check using glibc endian.h */
-#include <endian.h>
+#ifdef __APPLE__
+# include <machine/endian.h>
+#else
+# include <endian.h>
+#endif
 
 #if __BYTE_ORDER == __BIG_ENDIAN
 # define ARCH_IS_BIG_ENDIAN 1


### PR DESCRIPTION
endian.h is located in /usr/include/machine on OSX (rather than /usr/include).