### PR TITLE
corrected 'invalid option' error when using '-A'

### DIFF
--- a/fdupes.c
+++ b/fdupes.c
@@ -1068,7 +1068,7 @@ int main(int argc, char **argv) {
 
   oldargv = cloneargs(argc, argv);
 
-  while ((opt = GETOPT(argc, argv, "frRq1SsHlndvhNmpo:"
+  while ((opt = GETOPT(argc, argv, "frRq1SsHlnAdvhNmpo:"
 #ifndef OMIT_GETOPT_LONG
           , long_options, NULL
 #endif

--- a/md5/md5.c
+++ b/md5/md5.c
@@ -46,7 +46,11 @@
 #include <string.h>
 
 /* endianness check using glibc endian.h */
-#include <endian.h>
+#ifdef __APPLE__
+# include <machine/endian.h>
+#else
+# include <endian.h>
+#endif
 
 #if __BYTE_ORDER == __BIG_ENDIAN
 # define ARCH_IS_BIG_ENDIAN 1


### PR DESCRIPTION
Short option '-A' returned 'invalid option' error, although long option '--nohidden' worked.