### PR TITLE
Reverse filename sort order

### DIFF
--- a/fdupes.c
+++ b/fdupes.c
@@ -928,7 +928,7 @@ int sort_pairs_by_mtime(file_t *f1, file_t *f2)
 
 int sort_pairs_by_filename(file_t *f1, file_t *f2)
 {
-  return strcmp(f1->d_name, f2->d_name);
+  return -strcmp(f1->d_name, f2->d_name);
 }
 
 void registerpair(file_t **matchlist, file_t *newmatch, 


### PR DESCRIPTION
This produces the more natural (to my eye) sort order and gives this:

```
$ fdupes --recurse --order=name 10
10/Image07.jpg
10/Image07-13.jpg
10/Image07-11-2.jpg
10/Image07-10.jpg

10/Image06.jpg
10/Image06-14.jpg
10/Image06-14-2.jpg
10/Image06-10.jpg

10/Image05.jpg
10/Image05-14.jpg
10/Image05-14-2.jpg
10/Image05-10.jpg

10/Image04.jpg
10/Image04-14.jpg
10/Image04-14-2.jpg
10/Image04-10.jpg

10/Image03.jpg
10/Image03-14.jpg
10/Image03-12.jpg

10/Image02.jpg
10/Image02-13.jpg
10/Image02-11.jpg
10/Image02-10.jpg

```

instead of:

```
$ fdupes --recurse --order=name 10
10/Image02-10.jpg
10/Image02-11.jpg
10/Image02-13.jpg
10/Image02.jpg

10/Image06-10.jpg
10/Image06-14-2.jpg
10/Image06-14.jpg
10/Image06.jpg

10/Image07-10.jpg
10/Image07-11-2.jpg
10/Image07-13.jpg
10/Image07.jpg

10/Image04-10.jpg
10/Image04-14-2.jpg
10/Image04-14.jpg
10/Image04.jpg

10/Image05-10.jpg
10/Image05-14-2.jpg
10/Image05-14.jpg
10/Image05.jpg

10/Image03-12.jpg
10/Image03-14.jpg
10/Image03.jpg
```

which helps when running with `--delete --noprompt` for my use case when selecting more 'canonical' names, thanks.