### PR TITLE
Implemented sorting output duplicate files by size

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,7 @@ Usage: fdupes [options] DIRECTORY...
  -f --omitfirst   	omit the first file in each set of matches
  -1 --sameline    	list each set of matches on a single line
  -S --size        	show size of duplicate files
+ -z --sortbysize  	sort output by size of duplicate files (descending)
  -m --summarize   	summarize dupe information
  -q --quiet       	hide progress indicator
  -d --delete      	prompt user for files to preserve and delete all

--- a/fdupes.1
+++ b/fdupes.1
@@ -48,6 +48,9 @@ list each set of matches on a single line
 .B -S --size
 show size of duplicate files
 .TP
+.B -z --sortbysize
+sort output by size of duplicate files (descending)
+.TP
 .B -m --summarize
 summarize duplicate files information
 .TP


### PR DESCRIPTION
I always wanted this feature and saw there was also an item about it in the issue list.
After finding all the duplicate files, the list only has to be sorted by the size of those. I think mergesort is the best choice for the sorting algorithm because no memory has to be dynamically allocated and worst runtime is still O(n log (n)). I added the command line option -z or --sortbysize.
It worked without problems on the examples I tested.

Btw, thanks for the awesome work on fdupes!
