### PR TITLE
make summary compatible with other options

### DIFF
--- a/fdupes.c
+++ b/fdupes.c
@@ -1312,13 +1312,12 @@ int main(int argc, char **argv) {
   }
 
   else 
+  {
+    printmatches(files);
 
     if (ISFLAG(flags, F_SUMMARIZEMATCHES))
       summarizematches(files);
-      
-    else
-
-      printmatches(files);
+  }
 
   while (files) {
     curfile = files->next;


### PR DESCRIPTION
Lets consider case of call
fdupes -1 -r -m -S 
-m (--summary) option before the proposed pull request leads to printing just summary, even in the case when such options as -1 specified. However, the documentation states, that when -1 and -S is specified, than sizes of files are shown, and files are displayed on the same line. 

After the proposed fix, not only summary, but also duplicate files list is displayed, when summary flag is specified.