### PR TITLE
File mtime is now shown in ISO-8601 format alongside the filenames of dupes during interaction deletion.

### DIFF
--- a/fdupes.c
+++ b/fdupes.c
@@ -27,6 +27,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <time.h>
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #endif
@@ -179,6 +180,14 @@ time_t getctime(char *filename) {
   if (stat(filename, &s) != 0) return 0;
 
   return s.st_ctime;
+}
+
+char *fmtmtime(char *filename) {
+  static char buf[64];
+  time_t t = getmtime(filename);
+
+  strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", localtime(&t));
+  return buf;
 }
 
 char **cloneargs(int argc, char **argv)
@@ -937,13 +946,13 @@ void deletefiles(file_t *files, int prompt, FILE *tty, char *logfile)
       counter = 1;
       dupelist[counter] = files;
 
-      if (prompt) printf("[%d] %s\n", counter, files->d_name);
+      if (prompt) printf("[%d] [%s] %s\n", counter, fmtmtime(files->d_name), files->d_name);
 
       tmpfile = files->duplicates;
 
       while (tmpfile) {
 	dupelist[++counter] = tmpfile;
-	if (prompt) printf("[%d] %s\n", counter, tmpfile->d_name);
+	if (prompt) printf("[%d] [%s] %s\n", counter, fmtmtime(tmpfile->d_name), tmpfile->d_name);
 	tmpfile = tmpfile->duplicates;
       }
 


### PR DESCRIPTION
This feature is intended to make the user's life easier as some sorting decisions may be based on the age difference between duplicate files.

I wasn't able to add the timestamp display to the ncurses TUI version of the utility, as I couldn't for the life of me locate where the filenames are printed (either by regex or reading the code). If you have a file and line # for me to look at, I'd be more than happy to add it to the TUI as well :)