### PR TITLE
Improved ncurses detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,12 +6,16 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_ARG_PROGRAM
 
+PKG_PROG_PKG_CONFIG
+
 AC_ARG_WITH([ncurses], AS_HELP_STRING([--without-ncurses], [Do not use ncurses interface]))
 
 AC_CHECK_HEADERS([getopt.h ncursesw/curses.h])
 
 AS_IF([test x"$with_ncurses" != x"no"],
-	[AC_SEARCH_LIBS([wget_wch], [ncursesw ncurses curses], [], [AC_ERROR([ncurses library not found (or lacks wide character support)])])]
+	[PKG_CHECK_MODULES([NCURSES], [ncursesw],
+		[LIBS="$LIBS $NCURSES_LIBS"],
+		[AC_SEARCH_LIBS([wget_wch], [ncursesw ncurses curses], [], [AC_ERROR([ncurses library not found (or lacks wide character support)])])])]
 	[AC_DEFINE([_XOPEN_SOURCE], [], [enable certain functions in wchar.h])]
 	[AC_DEFINE([_XOPEN_SOURCE_EXTENDED], [], [enable certain functions in curses.h])]
 	[AC_DEFINE([_ISOC99_SOURCE], [], [enable strtoll])]

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,9 @@ AC_CHECK_HEADERS([getopt.h ncursesw/curses.h])
 AS_IF([test x"$with_ncurses" != x"no"],
 	[PKG_CHECK_MODULES([NCURSES], [ncursesw],
 		[LIBS="$LIBS $NCURSES_LIBS"],
-		[AC_SEARCH_LIBS([wget_wch], [ncursesw ncurses curses], [], [AC_ERROR([ncurses library not found (or lacks wide character support)])])])]
+		[AC_SEARCH_LIBS([wget_wch], [ncursesw ncurses curses], [], [AC_ERROR([ncurses library not found (or lacks wide character support)])])]
+		[AC_SEARCH_LIBS([keypad], [ncursesw tinfow ncurses tinfo curses], [], [AC_ERROR([ncurses library not found (lacks keypad support)])])]
+	)]
 	[AC_DEFINE([_XOPEN_SOURCE], [], [enable certain functions in wchar.h])]
 	[AC_DEFINE([_XOPEN_SOURCE_EXTENDED], [], [enable certain functions in curses.h])]
 	[AC_DEFINE([_ISOC99_SOURCE], [], [enable strtoll])]


### PR DESCRIPTION
* The first commit adds pkgconfig support to detect ncurses. This is the preferred way and configure falls back to `AC_SEARCH_LIBS` if pkgconfig isn't found or pkgconfig doesn't find `ncursesw`.
* The second commit fixes issue #138 by adding a second `AC_SEARCH_LIBS` call for the `keypad` function.