### PR TITLE
fix some warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AS_IF([test x"$with_ncurses" != x"no"],
 		[AC_SEARCH_LIBS([wget_wch], [ncursesw ncurses curses], [], [AC_ERROR([ncurses library not found (or lacks wide character support)])])]
 		[AC_SEARCH_LIBS([keypad], [ncursesw tinfow ncurses tinfo curses], [], [AC_ERROR([ncurses library not found (lacks keypad support)])])]
 	)]
-	[AC_DEFINE([_XOPEN_SOURCE], [], [enable certain functions in wchar.h])]
+	[AC_DEFINE([_XOPEN_SOURCE], [700], [enable certain functions in wchar.h])]
 	[AC_DEFINE([_XOPEN_SOURCE_EXTENDED], [], [enable certain functions in curses.h])]
 	[AC_DEFINE([_ISOC99_SOURCE], [], [enable strtoll])]
 	[AC_SEARCH_LIBS([pcre2_match_32], [pcre2-32], [], [AC_ERROR([pcre2 library not found])])]

--- a/ncurses-commands.c
+++ b/ncurses-commands.c
@@ -941,5 +941,5 @@ int cmd_prune(struct filegroup *groups, int groupcount, wchar_t *commandargument
       *topline = 0;
   }
 
-  cmd_clear_all_selections(groups, *totalgroups, commandarguments, 0);
+  return cmd_clear_all_selections(groups, *totalgroups, commandarguments, 0);
 }

--- a/ncurses-getcommand.c
+++ b/ncurses-getcommand.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #include <stdlib.h>
 #include <signal.h>
+#include <wctype.h>
 #include "ncurses-getcommand.h"
 
 #define KEY_ESCAPE 27

--- a/ncurses-interface.c
+++ b/ncurses-interface.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
+#include <wctype.h>
 #ifdef HAVE_NCURSESW_CURSES_H
   #include <ncursesw/curses.h>
 #else


### PR DESCRIPTION
spotted while building this on OpenBSD, probably helps on other platforms too.

 - define _XOPEN_SOURCE to an integral version big enough to have strcasecmp visible

 - fix the return type of cmd_prune

 - include wctype.h for the isw* functions
