### PR TITLE
WIP patch to prevent recursing into Synology @eaDir metadata folders

### DIFF
--- a/fdupes.c
+++ b/fdupes.c
@@ -384,8 +384,14 @@ int grokdir(char *dir, file_t **filelistp, struct stat *logfile_status)
       if (S_ISDIR(info.st_mode)) {
         if (ISFLAG(flags, F_RECURSE) && (ISFLAG(flags, F_FOLLOWLINKS) || !S_ISLNK(linfo.st_mode)))
         {
-          filesadded = grokdir(newfile->d_name, filelistp, logfile_status);
-          filecount += filesadded;
+          fullname = strdup(newfile->d_name);
+          name = basename(fullname);
+          if (strcmp(name, "@eaDir") != 0) {
+	    filesadded = grokdir(newfile->d_name, filelistp, logfile_status);
+            filecount += filesadded;
+          } else {
+            printf("Not recursving into @eaDir: %s!\n", fullname);
+          }
 
 #ifndef NO_SQLITE
           if (db != 0 && pathid == 0 && !ISFLAG(flags, F_READONLYCACHE) && filesadded > 0)


### PR DESCRIPTION
Synology NAS NFS mounts expose the internal `@eaDir` folders which the NAS uses to store file meta data.
These metadata files create lots of unhelpful duplicates when fdupes'ing a mounted file system.

Very crude patch to the recurse block to prevent the build file list step from recursing into these folders.

Work in progress; do not merge!
These solved my immediate problem. I will attempt to clean this up to into a safe command line option.
Offered as a draft PR incase anyone else has the same problem and wants to collaborate.
