### PR TITLE
Add flag to ignore inode changes in removeifnotchanged

### DIFF
--- a/README
+++ b/README
@@ -62,6 +62,7 @@ Usage: fdupes [options] DIRECTORY...
                          change time (BY='ctime'), or filename (BY='name')
  -i --reverse            reverse order while sorting
  -l --log=LOGFILE        log file deletion choices to LOGFILE
+ -e --noinodes           don't use inodes to test for changed file contents
  -v --version            display fdupes version
  -h --help               display this help message
 
@@ -84,6 +85,13 @@ once. All files within that directory will be listed as their own
 duplicates, leading to data loss should a user preserve a file
 without its "duplicate" (the file itself!).
 
+Some remote-mounted filesystems (e.g. gvfs-smb) generate inodes in
+the client instead of sending server inode values. With a large
+number of files or client cache activity, inodes can change even
+though the file has not changed or moved. Using -e or --noinodes
+allows fdupes to delete files where the device, creation and
+modification times, and size has not changed during processing, 
+ignoring any inode change. 
 
 Contact Information for Adrian Lopez
 --------------------------------------------------------------------

--- a/fdupes.1
+++ b/fdupes.1
@@ -127,6 +127,9 @@ Reverse order while sorting.
 .B -l --log\fR=\fILOGFILE\fR
 Log file deletion choices to LOGFILE.
 .TP
+.B -e --noinodes
+Don't use inodes to test for changed file contents.
+.TP
 .B -v --version
 Display fdupes version.
 .TP
@@ -147,6 +150,13 @@ or
 .B --sameline
 is specified, spaces and backslash characters  (\fB\e\fP) appearing
 in a filename are preceded by a backslash character.
+
+When
+.B -e
+or
+.B --noinodes
+is specified, file inode will not be used to test for file content
+changes before deletion.
 
 .SH EXAMPLES
 .TP

--- a/flags.h
+++ b/flags.h
@@ -28,6 +28,7 @@
 #define F_PRUNECACHE        0x200000
 #define F_READONLYCACHE     0x400000
 #define F_VACUUMCACHE       0x800000
+#define F_NOINODES          0x1000000
 
 extern unsigned long flags;
 

--- a/ncurses-commands.c
+++ b/ncurses-commands.c
@@ -715,6 +715,7 @@ int cmd_prune(struct filegroup *groups, int groupcount, wchar_t *commandargument
   wchar_t *statuscopy;
   struct groupfile *firstnotdeleted;
   char *deletepath;
+  int checkinode = !ISFLAG(flags, F_NOINODES);
 
   if (logfile != 0)
     loginfo = log_open(logfile, 0);
@@ -808,7 +809,7 @@ int cmd_prune(struct filegroup *groups, int groupcount, wchar_t *commandargument
           }
 #endif
 
-          if (ismatch && removeifnotchanged(groups[g].files[f].file, 0) == 0)
+          if (ismatch && removeifnotchanged(groups[g].files[f].file, 0, checkinode) == 0)
           {
             set_file_action(&groups[g].files[f], FILEACTION_DELIST, deletiontally);
 

--- a/removeifnotchanged.c
+++ b/removeifnotchanged.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <stdio.h>
 
-int removeifnotchanged(const file_t *file, char **errorstring)
+int removeifnotchanged(const file_t *file, char **errorstring, int checkinode)
 {
   int result;
   struct stat st;
@@ -36,7 +36,7 @@ int removeifnotchanged(const file_t *file, char **errorstring)
   stat(file->d_name, &st);
 
   if (file->device != st.st_dev ||
-      file->inode != st.st_ino ||
+      (checkinode && (file->inode != st.st_ino)) ||
       file->ctime != st.st_ctime ||
       file->mtime != st.st_mtime ||
 #ifdef HAVE_NSEC_TIMES

--- a/removeifnotchanged.h
+++ b/removeifnotchanged.h
@@ -24,6 +24,6 @@
 
 #include "fdupes.h"
 
-int removeifnotchanged(const file_t *file, char **errorstring);
+int removeifnotchanged(const file_t *file, char **errorstring, int checkinode);
 
 #endif


### PR DESCRIPTION
This commit adds a command line option (-e or --noinodes) to allow fdupes to remove duplicates even if the inode changes between calls to `stat()`. The following comment added to README explains: 

> Some remote-mounted filesystems (e.g. gvfs-smb) generate inodes in
> the client instead of sending server inode values. With a large
> number of files or client cache activity, inodes can change even
> though the file has not changed or moved. Using -e or --noinodes
> allows fdupes to delete files where the device, creation and
> modification times, and size has not changed during processing, 
> ignoring any inode change. 
