### PR TITLE
Add --protect-dir and --simulate/--dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Usage: fdupes [options] DIRECTORY...
                          delete files located at or below PATH; PATH and
                          each candidate file are resolved via realpath()
                          before comparison
+    --simulate           with --delete, print the [+] and [-] decisions
+    --dry-run            that would be made but do not actually unlink
+                         any files; no cache rows or log entries are
+                         written for the skipped deletions
  -v --version            display fdupes version
  -h --help               display this help message
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Usage: fdupes [options] DIRECTORY...
                          change time (BY='ctime'), or filename (BY='name')
  -i --reverse            reverse order while sorting
  -l --log=LOGFILE        log file deletion choices to LOGFILE
+ -X --protect-dir=PATH   with --delete and --noprompt/--immediate, never
+                         delete files located at or below PATH; PATH and
+                         each candidate file are resolved via realpath()
+                         before comparison
  -v --version            display fdupes version
  -h --help               display this help message
 

--- a/fdupes.1
+++ b/fdupes.1
@@ -155,6 +155,22 @@ the first file in the set (according to the current sort order) is
 preserved as usual. The option has no effect without
 .BR --delete .
 .TP
+.B --simulate
+.TP
+.B --dry-run
+When used together with
+.BR --delete ,
+print the
+.B [+]
+and
+.B [-]
+decisions that would be made for each duplicate set, but do not
+actually unlink any files. The cache database is not updated for
+the skipped deletions, and the log file (if any) will not record
+any "deleted" entries. The two options are aliases and have no
+effect without
+.BR --delete .
+.TP
 .B -v --version
 Display fdupes version.
 .TP

--- a/fdupes.1
+++ b/fdupes.1
@@ -131,6 +131,30 @@ Reverse order while sorting.
 .B -l --log\fR=\fILOGFILE\fR
 Log file deletion choices to LOGFILE.
 .TP
+.B -X --protect-dir\fR=\fIPATH\fR
+When used together with
+.B --delete
+and either
+.B --noprompt
+or
+.BR --immediate ,
+never delete files located at or below
+.IR PATH .
+Both
+.I PATH
+and each candidate file are resolved via
+.BR realpath (3)
+before comparison, so symbolic links and redundant components
+.RB ( . ", " .. ", " // )
+are normalized. If a duplicate set contains at least one file under
+.IR PATH ,
+only the protected files are preserved; if no file in the set is
+under
+.IR PATH ,
+the first file in the set (according to the current sort order) is
+preserved as usual. The option has no effect without
+.BR --delete .
+.TP
 .B -v --version
 Display fdupes version.
 .TP

--- a/fdupes.c
+++ b/fdupes.c
@@ -1117,7 +1117,7 @@ void deletefiles(file_t *files, int prompt, FILE *tty, char *logfile)
         if (!any_selected)
         {
           /* no files in this set are under --protect-dir;
-             fall back to preserving the first file (legacy behaviour) */
+             fall back to preserving the first file (legacy behavior) */
           preserve[1] = 1;
         }
       }
@@ -1870,6 +1870,13 @@ int main(int argc, char **argv) {
   if (ISFLAG(flags, F_DEFERCONFIRMATION) && (!ISFLAG(flags, F_DELETEFILES) || ISFLAG(flags, F_NOPROMPT)))
   {
     errormsg("--deferconfirmation only works with interactive deletion modes\n");
+    exit(1);
+  }
+
+  if (ISFLAG(flags, F_SIMULATE) && ISFLAG(flags, F_DELETEFILES)
+      && !ISFLAG(flags, F_NOPROMPT) && !ISFLAG(flags, F_IMMEDIATE))
+  {
+    errormsg("--simulate/--dry-run requires --noprompt or --immediate with --delete\n");
     exit(1);
   }
 

--- a/fdupes.c
+++ b/fdupes.c
@@ -73,6 +73,8 @@ sqlite3 *db;
 
 struct log_info *loginfo;
 
+char *protect_dir = 0;
+
 typedef enum {
   ORDER_MTIME = 0,
   ORDER_CTIME,
@@ -945,6 +947,60 @@ int relink(char *oldfile, char *newfile)
   return 1;
 }
 
+/* Canonicalize a path using realpath(); caller must free the result. */
+static char *canonicalize_path(const char *path)
+{
+  char *resolved;
+
+  if (path == 0)
+    return 0;
+
+  resolved = realpath(path, 0);
+  return resolved;
+}
+
+/* Return 1 if filepath is located at or below the protected directory,
+   0 otherwise. Both the protected directory and the file path are
+   canonicalized via realpath() before comparison. */
+static int is_under_protect_dir(const char *filepath)
+{
+  char *canon_filepath;
+  char *canon_protectdir;
+  size_t protectlen;
+  int result;
+
+  if (protect_dir == 0 || filepath == 0)
+    return 0;
+
+  canon_filepath = canonicalize_path(filepath);
+  if (canon_filepath == 0)
+    return 0;
+
+  canon_protectdir = canonicalize_path(protect_dir);
+  if (canon_protectdir == 0) {
+    free(canon_filepath);
+    return 0;
+  }
+
+  protectlen = strlen(canon_protectdir);
+  result = 0;
+
+  /* require exact match or filepath being strictly under the protected
+     directory (i.e. preceded by '/'); this avoids /foo/bar matching
+     /foo/barbaz */
+  if (strcmp(canon_filepath, canon_protectdir) == 0) {
+    result = 1;
+  } else if (strncmp(canon_filepath, canon_protectdir, protectlen) == 0
+             && canon_filepath[protectlen] == '/') {
+    result = 1;
+  }
+
+  free(canon_filepath);
+  free(canon_protectdir);
+
+  return result;
+}
+
 void deletefiles(file_t *files, int prompt, FILE *tty, char *logfile)
 {
   int counter;
@@ -1040,10 +1096,30 @@ void deletefiles(file_t *files, int prompt, FILE *tty, char *logfile)
 
       if (prompt) printf("\n");
 
-      if (!prompt) /* preserve only the first file */
+      if (!prompt) /* preserve files, deleting the rest */
       {
-         preserve[1] = 1;
-	 for (x = 2; x <= counter; x++) preserve[x] = 0;
+        int any_selected = 0;
+
+        for (x = 1; x <= counter; x++) preserve[x] = 0;
+
+        if (protect_dir != 0)
+        {
+          for (x = 1; x <= counter; x++)
+          {
+            if (is_under_protect_dir(dupelist[x]->d_name))
+            {
+              preserve[x] = 1;
+              any_selected = 1;
+            }
+          }
+        }
+
+        if (!any_selected)
+        {
+          /* no files in this set are under --protect-dir;
+             fall back to preserving the first file (legacy behaviour) */
+          preserve[1] = 1;
+        }
       }
 
       else /* prompt for files to preserve */
@@ -1332,8 +1408,28 @@ void deletesuccessor(file_t **existing, file_t *duplicate, int matchconfirmed,
   file_t *to_delete;
   char *deletepath;
   char *errorstring;
+  int existing_protected = 0;
+  int duplicate_protected = 0;
 
-  if (comparef(duplicate, *existing) >= 0)
+  if (protect_dir != 0)
+  {
+    existing_protected = is_under_protect_dir((*existing)->d_name);
+    duplicate_protected = is_under_protect_dir(duplicate->d_name);
+  }
+
+  if (existing_protected && !duplicate_protected)
+  {
+    to_keep = *existing;
+    to_delete = duplicate;
+  }
+  else if (duplicate_protected && !existing_protected)
+  {
+    to_keep = duplicate;
+    to_delete = *existing;
+
+    *existing = duplicate;
+  }
+  else if (comparef(duplicate, *existing) >= 0)
   {
     to_keep = *existing;
     to_delete = duplicate;
@@ -1467,6 +1563,10 @@ void help_text()
   printf("                         change time (BY='ctime'), or filename (BY='name')\n");
   printf(" -i --reverse            reverse order while sorting\n");
   printf(" -l --log=LOGFILE        log file deletion choices to LOGFILE\n");
+  printf(" -X --protect-dir=PATH   with --delete and --noprompt/--immediate, never\n");
+  printf("                         delete files located at or below PATH; PATH and\n");
+  printf("                         each candidate file are resolved via realpath()\n");
+  printf("                         before comparison\n");
   printf(" -v --version            display fdupes version\n");
   printf(" -h --help               display this help message\n\n");
 #ifndef HAVE_GETOPT_H
@@ -1554,6 +1654,7 @@ int main(int argc, char **argv) {
     { "log", 1, 0, 'l' },
     { "deferconfirmation", 0, 0, 'D' },
     { "cache", 0, 0, 'c' },
+    { "protect-dir", 1, 0, 'X' },
     { 0, 0, 0, 0 }
   };
 #define GETOPT getopt_long
@@ -1567,7 +1668,7 @@ int main(int argc, char **argv) {
 
   oldargv = cloneargs(argc, argv);
 
-  while ((opt = GETOPT(argc, argv, "frRq1StsHG:L:nAdPvhNImMpo:il:Dcx:"
+  while ((opt = GETOPT(argc, argv, "frRq1StsHG:L:nAdPvhNImMpo:il:Dcx:X:"
 #ifdef HAVE_GETOPT_H
           , long_options, NULL
 #endif
@@ -1674,6 +1775,22 @@ int main(int argc, char **argv) {
     case 'c':
       SETFLAG(flags, F_CACHESIGNATURES);
       break;
+    case 'X':
+    {
+      char *resolved;
+
+      resolved = realpath(optarg, 0);
+      if (resolved == 0)
+      {
+        errormsg("--protect-dir: cannot resolve path '%s': %s\n", optarg, strerror(errno));
+        exit(1);
+      }
+
+      free(protect_dir);
+      protect_dir = resolved;
+      SETFLAG(flags, F_PROTECTDIR);
+      break;
+    }
     case 'x':
       if (strcmp("cache.readonly", optarg) == 0)
         SETFLAG(flags, F_READONLYCACHE);

--- a/fdupes.c
+++ b/fdupes.c
@@ -1247,7 +1247,10 @@ void deletefiles(file_t *files, int prompt, FILE *tty, char *logfile)
     }
 
     if (ismatch) {
-      if (removeifnotchanged(dupelist[x], &errorstring) == 0) {
+      if (ISFLAG(flags, F_SIMULATE)) {
+        printf("   [-] %s  (simulated; not deleted)\n", dupelist[x]->d_name);
+      }
+      else if (removeifnotchanged(dupelist[x], &errorstring) == 0) {
         printf("   [-] %s\n", dupelist[x]->d_name);
 
 #ifndef NO_SQLITE
@@ -1454,7 +1457,10 @@ void deletesuccessor(file_t **existing, file_t *duplicate, int matchconfirmed,
 
   if (matchconfirmed)
   {
-    if (removeifnotchanged(to_delete, &errorstring) == 0) {
+    if (ISFLAG(flags, F_SIMULATE)) {
+      printf("   [-] %s  (simulated; not deleted)\n", to_delete->d_name);
+    }
+    else if (removeifnotchanged(to_delete, &errorstring) == 0) {
       printf("   [-] %s\n", to_delete->d_name);
 
 #ifndef NO_SQLITE
@@ -1567,6 +1573,10 @@ void help_text()
   printf("                         delete files located at or below PATH; PATH and\n");
   printf("                         each candidate file are resolved via realpath()\n");
   printf("                         before comparison\n");
+  printf("    --simulate           with --delete, print the [+] and [-] decisions\n");
+  printf("    --dry-run            that would be made but do not actually unlink\n");
+  printf("                         any files; no cache rows or log entries are\n");
+  printf("                         written for the skipped deletions\n");
   printf(" -v --version            display fdupes version\n");
   printf(" -h --help               display this help message\n\n");
 #ifndef HAVE_GETOPT_H
@@ -1655,6 +1665,8 @@ int main(int argc, char **argv) {
     { "deferconfirmation", 0, 0, 'D' },
     { "cache", 0, 0, 'c' },
     { "protect-dir", 1, 0, 'X' },
+    { "simulate", 0, 0, 'Y' },
+    { "dry-run", 0, 0, 'Y' },
     { 0, 0, 0, 0 }
   };
 #define GETOPT getopt_long
@@ -1668,7 +1680,7 @@ int main(int argc, char **argv) {
 
   oldargv = cloneargs(argc, argv);
 
-  while ((opt = GETOPT(argc, argv, "frRq1StsHG:L:nAdPvhNImMpo:il:Dcx:X:"
+  while ((opt = GETOPT(argc, argv, "frRq1StsHG:L:nAdPvhNImMpo:il:Dcx:X:Y"
 #ifdef HAVE_GETOPT_H
           , long_options, NULL
 #endif
@@ -1791,6 +1803,9 @@ int main(int argc, char **argv) {
       SETFLAG(flags, F_PROTECTDIR);
       break;
     }
+    case 'Y':
+      SETFLAG(flags, F_SIMULATE);
+      break;
     case 'x':
       if (strcmp("cache.readonly", optarg) == 0)
         SETFLAG(flags, F_READONLYCACHE);
@@ -2052,6 +2067,11 @@ int main(int argc, char **argv) {
 
   if (ISFLAG(flags, F_DELETEFILES))
   {
+    if (ISFLAG(flags, F_SIMULATE))
+    {
+      fprintf(stderr, "\n*** --simulate/--dry-run: no files will be deleted ***\n\n");
+    }
+
     if (ISFLAG(flags, F_NOPROMPT) || ISFLAG(flags, F_IMMEDIATE))
     {
       deletefiles(files, 0, 0, logfile);

--- a/flags.h
+++ b/flags.h
@@ -30,6 +30,7 @@
 #define F_VACUUMCACHE       0x800000
 #define F_QUICKSUMMARY     0x1000000
 #define F_PROTECTDIR       0x2000000
+#define F_SIMULATE         0x4000000
 
 extern unsigned long flags;
 

--- a/flags.h
+++ b/flags.h
@@ -29,6 +29,7 @@
 #define F_READONLYCACHE     0x400000
 #define F_VACUUMCACHE       0x800000
 #define F_QUICKSUMMARY     0x1000000
+#define F_PROTECTDIR       0x2000000
 
 extern unsigned long flags;
 


### PR DESCRIPTION
I keep a sorted folder with my long-term file collection, but accidentally re-download things often. I wanted `fdupes` to clean up the download folders without me confirming every duplicate set by hand, while leaving the sorted folder alone.

This adds two options:
```
 -X --protect-dir=PATH   with --delete and --noprompt/--immediate, never
                         delete files located at or below PATH; PATH and
                         each candidate file are resolved via realpath()
                         before comparison
    --simulate           with --delete, print the [+] and [-] decisions
    --dry-run            that would be made but do not actually unlink
                         any files; no cache rows or log entries are
                         written for the skipped deletions
```

Both `PATH` and each candidate file are resolved with `realpath(3)`, so symlinks and `..` are handled the way you'd expect.

`--simulate` is the natural way to verify that `--protect-dir` is doing what you expect before running it for real.

`--simulate` errors out if used without `--noprompt` or `--immediate`, since the interactive TUI would otherwise still let you delete via the prune command.